### PR TITLE
allow for converting between different public key formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ add the `secp256k1` library to your `shard.yml`
 dependencies:
   secp256k1:
     github: q9f/secp256k1.cr
-    version: "~> 0.1.1"
+    version: "~> 0.1.2"
 ```
 
 # usage
@@ -31,7 +31,5 @@ puts Secp256k1.public_key_compressed_prefix public_key
 
 create a pull request, and make sure tests and linter passes.
 
-this pure crystal implementation is based on the python implementation [wobine/blackboard101](https://github.com/wobine/blackboard101) which is also used as reference to write tests against.
-
-it's a complete rewrite of the abandoned [packetzero/bitcoinutils](https://github.com/packetzero/bitcoinutils) for educational purposes.
+this pure crystal implementation is based on the python implementation [wobine/blackboard101](https://github.com/wobine/blackboard101) which is also used as reference to write tests against. it's a complete rewrite of the abandoned [packetzero/bitcoinutils](https://github.com/packetzero/bitcoinutils) for educational purposes. should not be used in production without proper auditing.
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: secp256k1
-version: 0.1.1
+version: 0.1.2
 description: "a native library implementing secp256k1 for the crystal language"
 
 authors:

--- a/spec/secp256k1_spec.cr
+++ b/spec/secp256k1_spec.cr
@@ -106,15 +106,30 @@ describe Secp256k1 do
     p.x.should eq BigInt.new "3423904187495496827825042940737875085827330420143621346629173781207857376010"
     p.y.should eq BigInt.new "75711134420273723792089656449854389054866833762486990555172221523628676983696"
 
-    # > the uncompressed public key (hex):
+    # the uncompressed public key (hex):
     # > 040791dc70b75aa995213244ad3f4886d74d61ccd3ef658243fcad14c9ccee2b0aa762fbc6ac0921b8f17025bb8458b92794ae87a133894d70d7995fc0b6b5ab90
     uncm = Secp256k1.public_key_uncompressed_prefix p
     uncm.should eq "040791dc70b75aa995213244ad3f4886d74d61ccd3ef658243fcad14c9ccee2b0aa762fbc6ac0921b8f17025bb8458b92794ae87a133894d70d7995fc0b6b5ab90"
 
-    # > the official public key - compressed:
+    # the official public key - compressed:
     # > 020791dc70b75aa995213244ad3f4886d74d61ccd3ef658243fcad14c9ccee2b0a
     publ = Secp256k1.public_key_compressed_prefix p
     publ.should eq "020791dc70b75aa995213244ad3f4886d74d61ccd3ef658243fcad14c9ccee2b0a"
+
+    # taking the private key from bitcointalk
+    # ref: https://bitcointalk.org/index.php?topic=644919.msg7205689#msg7205689
+    priv = BigInt.new "55255657523dd1c65a77d3cb53fcd050bf7fc2c11bb0bb6edabdbd41ea51f641", 16
+    priv.should eq BigInt.new "38512561375336666218975019341699212961293425532484539208601808874461264475713"
+    p = Secp256k1.public_key_from_private priv
+
+    # > compressed_key = '0314fc03b8df87cd7b872996810db8458d61da8448e531569c8517b469a119d267'
+    publ = Secp256k1.public_key_compressed_prefix p
+    publ.should eq "0314fc03b8df87cd7b872996810db8458d61da8448e531569c8517b469a119d267"
+
+    # > uncompressed_key = '04{:x}{:x}'.format(x, y)
+    # > 0414fc03b8df87cd7b872996810db8458d61da8448e531569c8517b469a119d267be5645686309c6e6736dbd93940707cc9143d3cf29f1b877ff340e2cb2d259cf
+    uncm = Secp256k1.public_key_uncompressed_prefix p
+    uncm.should eq "0414fc03b8df87cd7b872996810db8458d61da8448e531569c8517b469a119d267be5645686309c6e6736dbd93940707cc9143d3cf29f1b877ff340e2cb2d259cf"
   end
 
   # makes sure no ec multiplication is done with invalid private keys

--- a/spec/secp256k1_spec.cr
+++ b/spec/secp256k1_spec.cr
@@ -138,7 +138,7 @@ describe Secp256k1 do
     key_too_high = BigInt.new "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 16
 
     # zero or greater field size should raise an exception
-    expect_raises(Exception, "invalid private key: outside of ec field size.") do
+    expect_raises Exception, "invalid private key: outside of ec field size." do
       Secp256k1.public_key_from_private key_too_low
       Secp256k1.public_key_from_private key_too_high
     end
@@ -160,47 +160,37 @@ describe Secp256k1 do
     p = Secp256k1.restore_public_key uncompressed_with_prefix
     q = Secp256k1.restore_public_key uncompressed_without_prefix
 
-    # this nil? check is required to circumvent a compiler bug
-    # ref: https://github.com/crystal-lang/crystal/issues/6002
-    if p.nil? || q.nil?
-      raise "public key ec point restauration failed"
-    else
-      # testing against the same key from the python blackboard 101
-      p.x.should eq BigInt.new "3423904187495496827825042940737875085827330420143621346629173781207857376010"
-      p.y.should eq BigInt.new "75711134420273723792089656449854389054866833762486990555172221523628676983696"
-      q.x.should eq BigInt.new "3423904187495496827825042940737875085827330420143621346629173781207857376010"
-      q.y.should eq BigInt.new "75711134420273723792089656449854389054866833762486990555172221523628676983696"
-    end
+    # testing against the same key from the python blackboard 101
+    p.not_nil!.x.should eq BigInt.new "3423904187495496827825042940737875085827330420143621346629173781207857376010"
+    p.not_nil!.y.should eq BigInt.new "75711134420273723792089656449854389054866833762486990555172221523628676983696"
+    q.not_nil!.x.should eq BigInt.new "3423904187495496827825042940737875085827330420143621346629173781207857376010"
+    q.not_nil!.y.should eq BigInt.new "75711134420273723792089656449854389054866833762486990555172221523628676983696"
 
     # compressed keys can only be restored with prefix
     compressed_with_prefix = "020791dc70b75aa995213244ad3f4886d74d61ccd3ef658243fcad14c9ccee2b0a"
-    r = Secp256k1.restore_public_key compressed_with_prefix
-
-    # this nil? check is required to circumvent a compiler bug
-    # ref: https://github.com/crystal-lang/crystal/issues/6002
-    if r.nil?
-      raise "public key ec point restauration failed"
-    else
-      # testing against the same key from the python blackboard 101
-      r.x.should eq BigInt.new "3423904187495496827825042940737875085827330420143621346629173781207857376010"
-      r.y.should eq BigInt.new "75711134420273723792089656449854389054866833762486990555172221523628676983696"
+    expect_raises Exception, "this is not possible in crystal yet (#8612)" do
+      # @TODO remove this raise once #8612 is fixed
+      r = Secp256k1.restore_public_key compressed_with_prefix
+      # # testing against the same key from the python blackboard 101
+      # r.not_nil!.x.should eq BigInt.new "3423904187495496827825042940737875085827330420143621346629173781207857376010"
+      # r.not_nil!.y.should eq BigInt.new "75711134420273723792089656449854389054866833762486990555172221523628676983696"
     end
 
     # compressed without prefix should raise an exception
     compressed_without_prefix = "0791dc70b75aa995213244ad3f4886d74d61ccd3ef658243fcad14c9ccee2b0a"
-    expect_raises(Exception, "unknown public key format (invalid key size: 64)") do
+    expect_raises Exception, "unknown public key format (invalid key size: 64)" do
       Secp256k1.restore_public_key compressed_without_prefix
     end
 
     # invalid key (cut off) should raise an exception
     uncompressed_invalid = "040791dc70b75aa995213244ad3f4886d74d61ccd3ef658243fcad14c9ccee2b0aa762fbc6ac0921b8f17025bb"
-    expect_raises(Exception, "unknown public key format (invalid key size: 90)") do
+    expect_raises Exception, "unknown public key format (invalid key size: 90)" do
       Secp256k1.restore_public_key uncompressed_invalid
     end
 
     # invalid key (invalid prefix) should raise an exception
     compressed_invalid = "080791dc70b75aa995213244ad3f4886d74d61ccd3ef658243fcad14c9ccee2b0a"
-    expect_raises(Exception, "invalid prefix for compressed public key: 08") do
+    expect_raises Exception, "invalid prefix for compressed public key: 08" do
       Secp256k1.restore_public_key compressed_invalid
     end
   end

--- a/spec/secp256k1_spec.cr
+++ b/spec/secp256k1_spec.cr
@@ -173,10 +173,18 @@ describe Secp256k1 do
     end
 
     # compressed keys can only be restored with prefix
-    # compressed_with_prefix = "020791dc70b75aa995213244ad3f4886d74d61ccd3ef658243fcad14c9ccee2b0a"
-    # @TODO: this currently overflows due to the lack of mod_exp support in Crystal
-    # ref: https://stackoverflow.com/q/59454729/1260906
-    # r = Secp256k1.restore_public_key compressed_with_prefix
+    compressed_with_prefix = "020791dc70b75aa995213244ad3f4886d74d61ccd3ef658243fcad14c9ccee2b0a"
+    r = Secp256k1.restore_public_key compressed_with_prefix
+
+    # this nil? check is required to circumvent a compiler bug
+    # ref: https://github.com/crystal-lang/crystal/issues/6002
+    if r.nil?
+      raise "public key ec point restauration failed"
+    else
+      # testing against the same key from the python blackboard 101
+      r.x.should eq BigInt.new "3423904187495496827825042940737875085827330420143621346629173781207857376010"
+      r.y.should eq BigInt.new "75711134420273723792089656449854389054866833762486990555172221523628676983696"
+    end
 
     # compressed without prefix should raise an exception
     compressed_without_prefix = "0791dc70b75aa995213244ad3f4886d74d61ccd3ef658243fcad14c9ccee2b0a"

--- a/spec/secp256k1_spec.cr
+++ b/spec/secp256k1_spec.cr
@@ -136,4 +136,49 @@ describe Secp256k1 do
       iter += 1
     end
   end
+
+  # should be able to recover ec points from compressed public key strings
+  it "restores public ec point from public key strings" do
+    # uncompressed keys can be restored with or without prefix
+    uncompressed_with_prefix = "040791dc70b75aa995213244ad3f4886d74d61ccd3ef658243fcad14c9ccee2b0aa762fbc6ac0921b8f17025bb8458b92794ae87a133894d70d7995fc0b6b5ab90"
+    uncompressed_without_prefix = "0791dc70b75aa995213244ad3f4886d74d61ccd3ef658243fcad14c9ccee2b0aa762fbc6ac0921b8f17025bb8458b92794ae87a133894d70d7995fc0b6b5ab90"
+    p = Secp256k1.restore_public_key uncompressed_with_prefix
+    q = Secp256k1.restore_public_key uncompressed_without_prefix
+
+    # this nil? check is required to circumvent a compiler bug
+    # ref: https://github.com/crystal-lang/crystal/issues/6002
+    if p.nil? || q.nil?
+      raise "public key ec point restauration failed"
+    else
+      # testing against the same key from the python blackboard 101
+      p.x.should eq BigInt.new "3423904187495496827825042940737875085827330420143621346629173781207857376010"
+      p.y.should eq BigInt.new "75711134420273723792089656449854389054866833762486990555172221523628676983696"
+      q.x.should eq BigInt.new "3423904187495496827825042940737875085827330420143621346629173781207857376010"
+      q.y.should eq BigInt.new "75711134420273723792089656449854389054866833762486990555172221523628676983696"
+    end
+
+    # compressed keys can only be restored with prefix
+    # compressed_with_prefix = "020791dc70b75aa995213244ad3f4886d74d61ccd3ef658243fcad14c9ccee2b0a"
+    # @TODO: this currently overflows due to the lack of mod_exp support in Crystal
+    # ref: https://stackoverflow.com/q/59454729/1260906
+    # r = Secp256k1.restore_public_key compressed_with_prefix
+
+    # compressed without prefix should raise an exception
+    compressed_without_prefix = "0791dc70b75aa995213244ad3f4886d74d61ccd3ef658243fcad14c9ccee2b0a"
+    expect_raises(Exception, "unknown public key format (invalid key size: 64)") do
+      Secp256k1.restore_public_key compressed_without_prefix
+    end
+
+    # invalid key (cut off) should raise an exception
+    uncompressed_invalid = "040791dc70b75aa995213244ad3f4886d74d61ccd3ef658243fcad14c9ccee2b0aa762fbc6ac0921b8f17025bb"
+    expect_raises(Exception, "unknown public key format (invalid key size: 90)") do
+      Secp256k1.restore_public_key uncompressed_invalid
+    end
+
+    # invalid key (invalid prefix) should raise an exception
+    compressed_invalid = "080791dc70b75aa995213244ad3f4886d74d61ccd3ef658243fcad14c9ccee2b0a"
+    expect_raises(Exception, "invalid prefix for compressed public key: 08") do
+      Secp256k1.restore_public_key compressed_invalid
+    end
+  end
 end

--- a/src/utils.cr
+++ b/src/utils.cr
@@ -67,6 +67,10 @@ module Secp256k1
         # x is simply the coordinate
         x = BigInt.new pub[2, 64], 16
 
+        # note: this is not possible yet due to lack of mod_exp support in Crystal
+        # ref: https://github.com/crystal-lang/crystal/issues/8612
+        raise "this is not possible in crystal yet (#8612)"
+
         # y is on our curve (x^3 + 7) ^ ((p + 1) / 4) % p
         a = x ** 3 % prime
         a = (a + 7) % prime

--- a/src/version.cr
+++ b/src/version.cr
@@ -14,5 +14,5 @@
 
 module Secp256k1
   # the version of the module
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION
blocked by missing `mod_exp` https://stackoverflow.com/q/59454729/1260906

also, ref https://github.com/crystal-lang/crystal/issues/6002 https://github.com/crystal-lang/crystal/issues/8612